### PR TITLE
Made the /util/ only accept POST HTTP requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,6 +136,7 @@ const fetchHandler = async function (req) {
   }
 
   if (urlPath[0] === "util") {
+    if (req.method !== "POST") return Response("ERR_METHOD", { status: 405 });
 
     const util = utils[urlPath[1]];
     const args = urlPath.slice(2).map(decodeURIComponent);

--- a/pages/admin/cli/index.html
+++ b/pages/admin/cli/index.html
@@ -165,7 +165,9 @@
 
         }
 
-        const response = await fetch(`/util/${util}/${args.join("/")}`);
+        const response = await fetch(`/util/${util}/${args.join("/")}`, {
+          method: 'POST'
+        });
         console.log(response);
 
         if (response.status === 404) return output.innerHTML += "Command or module not found.<br>";


### PR DESCRIPTION
To avoid an organizer being dumb and clicking on a bad link.