### PR TITLE
Limit background animation's FPS

### DIFF
--- a/pages/bg.js
+++ b/pages/bg.js
@@ -106,8 +106,8 @@ function init () {
   }
 }
 
+const fpsCap = 30
 function animate () {
-
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
   dots.forEach((dot) => {
@@ -115,9 +115,9 @@ function animate () {
     dot.update();
     dot.connect(dots.filter((otherDot) => dot !== otherDot));
   });
-
-  requestAnimationFrame(animate);
-
+  
+  setTimeout(() => requestAnimationFrame(animate), 1000/fpsCap)
+  
 }
 
 init();

--- a/pages/main.js
+++ b/pages/main.js
@@ -260,7 +260,7 @@ var homepageInit = async function () {
       return;
     }
     removeRunConfirm = null;
-
+    hideTooltip();
     try {
 
       // Fetch api to remove run


### PR DESCRIPTION
Potential fix for #46. The dot's movement speed may also need to be multiplied.