### PR TITLE
Implement server timestamps for demos

### DIFF
--- a/api/timestamp.js
+++ b/api/timestamp.js
@@ -1,0 +1,26 @@
+/**
+ * Handles `/api/timestamp/` endpoint requests. This endpoint supports only the `get` command:
+ *
+ * - `get`: Fetch the server time in milliseconds from January 1, 1970, UTC
+ *
+ * @param {string[]} args The arguments for the api request
+ * @param {HttpRequest} request The http request object
+ * @returns {object} The response of the api request
+ */
+module.exports = async function (args, request) {
+
+  const [command] = args;
+
+  switch (command) {
+
+    case "get": {
+
+      return Date.now();
+
+    }
+
+  }
+
+  return "ERR_COMMAND";
+
+};

--- a/defaults/portal2/scripts/vscripts/mapspawn.nut
+++ b/defaults/portal2/scripts/vscripts/mapspawn.nut
@@ -357,8 +357,38 @@ ppmod.onauto(async(function () {
       EntFire(nextSplit.name, "Trigger");
       nextSplit.name = null;
 
+      // Request timestamp on split for additional verification opportunities
+      printl("[RequestTimestamp]");
+
     });
+
+    // Request a timestamp from the server at the start of each run
+    printl("[RequestTimestamp]");
 
   }, 0.2);
 
 }));
+
+::serverUnreachable <- function () {
+
+  local title = ppmod.text("Server Unreachable", -1, 0.4);
+  local text = ppmod.text(
+    "Failed to request data from the Epochtal API.\n" +
+    "Please make sure you're connected to the internet and restart the run.\n" +
+    "Runs performed offline are not verifiable and will be rejected.",
+    -1, 0.5
+  );
+
+  title.SetSize(5);
+  text.SetSize(0);
+  title.SetColor("255 100 100");
+  text.SetColor("255 100 100");
+
+  ppmod.interval(function ():(title, text) {
+    title.Display();
+    text.Display();
+  });
+
+  SendToConsole("fadeout 0.5 30 0 0 0");
+
+};

--- a/main.js
+++ b/main.js
@@ -157,18 +157,6 @@ const fetchHandler = async function (req) {
   const urlPath = url.pathname.split("/").slice(1);
   const userAgent = req.headers.get("User-Agent");
 
-  // Handle Spplice calls
-  if (!userAgent || userAgent.startsWith("Bun/") || userAgent.includes("spplice/2")) {
-
-    const path = `${epochtal.file.spplice.repository}/${urlPath[0]}`;
-    if (!fs.existsSync(path) || !urlPath[0]) {
-      return Response.json(await utils.spplice(["get"]));
-    }
-
-    return Response(Bun.file(path));
-
-  }
-
   // Handle WebSocket connections
   if (urlPath[0] === "ws") {
 
@@ -267,6 +255,18 @@ const fetchHandler = async function (req) {
     }
 
     return Response.json(result);
+
+  }
+
+  // Handle Spplice calls
+  if (!userAgent || userAgent.startsWith("Bun/") || userAgent.includes("spplice/2")) {
+
+    const path = `${epochtal.file.spplice.repository}/${urlPath[0]}`;
+    if (!fs.existsSync(path) || !urlPath[0]) {
+      return Response.json(await utils.spplice(["get"]));
+    }
+
+    return Response(Bun.file(path));
 
   }
 

--- a/util/gamefiles.js
+++ b/util/gamefiles.js
@@ -158,6 +158,8 @@ async function buildFiles (context) {
   await Bun.write(`${portal2}/scripts/vscripts/epochtal_map.nut`, `::epochtal_map <- ["${mapPaths.join('", "')}"]`);
   // Write current week number to epochtal_week.cfg as an svar
   await Bun.write(`${portal2}/cfg/epochtal_week.cfg`, `svar_set epochtal_week ${week.number}`);
+  // Write the server's address to allow for API access from Spplice JS interface
+  await Bun.write(`${portal2}/address.txt`, `${gconfig.tls ? "https" : "http"}://${gconfig.domain}`);
 
   // Create checksums for all created files
   let checksums = "\n// Epochtal files";


### PR DESCRIPTION
This resolves one of the goals of #36, which is to use the server clock to verify the time at which a demo was recorded. The issue isn't fully resolved, as it's still trivially easy to fool this system by modifying the package's `main.js` script before it gets loaded. To resolve that, the proposal mentioned in that issue's comments needs to be implemented, which I'll probably do tomorrow with a different pull request.