### PR TITLE
Fix find command not handling multiple users with the same name

### DIFF
--- a/util/users.js
+++ b/util/users.js
@@ -48,7 +48,7 @@ module.exports = async function (args, context = epochtal) {
       // Here, "steamid" is the search query
       for (const curr in users) {
         if (users[curr].name.toLowerCase().includes(steamid.toLowerCase())) {
-          output[users[curr].name] = curr;
+          output[curr] = users[curr].name;
         }
       }
 


### PR DESCRIPTION
Uses the steam id for the key of object being returned instead of the name, Fixing #26