### PR TITLE
Fix concludeWeek routine fail on long demo summaries

### DIFF
--- a/routines/epochtal.js
+++ b/routines/epochtal.js
@@ -57,17 +57,21 @@ async function concludeWeek (context) {
   }
   if (timescales.length === 0) textTimescales += "*All demos clean, nothing to report.*";
 
-  // Print report to console
+  // Print report to console and save it to file
   const finalReportText = `${textSummary}\n${textTimescales}`;
   UtilPrint("epochtal(concludeWeek):\n" + finalReportText);
+
+  const finalReportPath = (await tmppath()) + ".md";
+  await Bun.write(finalReportPath, finalReportText);
 
   // Report the summary including the demo files on Discord
   const demoTarPath = (await tmppath()) + ".tar";
   await $`tar -cf ${demoTarPath} -C ${context.file.demos} .`.quiet();
 
   try {
-    await discord(["report", finalReportText, [demoTarPath]], context);
+    await discord(["report", `Week ${week.number} demo report summary:`, [finalReportPath, demoTarPath]], context);
   } finally {
+    fs.unlinkSync(finalReportPath);
     fs.unlinkSync(demoTarPath);
   }
 

--- a/routines/epochtal.js
+++ b/routines/epochtal.js
@@ -45,15 +45,15 @@ async function concludeWeek (context) {
   // Create a summary of all suspicious demo events
   const { summary, timescales } = await summarizeDemoEvents(context);
 
-  let textSummary = "## [ Demo event summary ]\n";
+  let textSummary = "## Demo event summary\n";
   for (let i = 0; i < summary.length; i ++) {
-    textSummary += `\`${summary[i].cvar}\` in ${summary[i].count} demo${summary[i].count === 1 ? "" : "s"}: \`\`\`json\n${JSON.stringify(summary[i].demos)}\`\`\`\n`;
+    textSummary += `\`${summary[i].cvar}\` in ${summary[i].count} demo${summary[i].count === 1 ? "" : "s"}:\n- \`${summary[i].demos.join("`\n- `")}\`\n\n`;
   }
   if (summary.length === 0) textSummary += "*All demos clean, nothing to report.*";
 
-  let textTimescales = "## [ Demo timescale summary ]\n";
+  let textTimescales = "## Demo timescale summary\n";
   for (let i = 0; i < timescales.length; i ++) {
-    textTimescales += `\`${timescales[i].average.toFixed(5)}\` average in \`${timescales[i].demo}\`:\`\`\`json\n${JSON.stringify(timescales[i].array)}\`\`\`\n`;
+    textTimescales += `\`${timescales[i].average.toFixed(5)}\` average in \`${timescales[i].demo}\`:\n- \`${timescales[i].array.join(", ")}\`\n\n`;
   }
   if (timescales.length === 0) textTimescales += "*All demos clean, nothing to report.*";
 


### PR DESCRIPTION
Sends the final demo summary as a markdown file and changes formatting slightly to make it more compatible with basic markdown readers.

Closes #92