### PR TITLE
fix: use https when curating

### DIFF
--- a/util/curator.js
+++ b/util/curator.js
@@ -1,7 +1,7 @@
 const UtilError = require("./error.js");
 const UtilPrint = require("./print.js");
 
-const https = require("http");
+const https = require("https");
 const fs = require("node:fs");
 const weights = require(`${gconfig.secretsdir}/weights.js`);
 


### PR DESCRIPTION
While settings up Epochtal for local testing the curation would fail with this error:
![image](https://github.com/user-attachments/assets/7cb5fbf7-6869-4797-81f2-5cae2fede5a0)
I'm *pretty sure* workshop downloads always were https, so why suddenly Bun complains about not accepting https is a little bit of a mystery to me. My best guess is a bun update "fixed" `require('http')` to not accept https links anymore, because I saw some changes to the http engine in the Bun changelog. Either way, https fixed the issue.