### PR TITLE
Implement leaderboard countdown

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -61,7 +61,7 @@
 
       <div class="section" id="leaderboard">
 
-        <p class="center font-light marginb-small" id="leaderboard-countdown">Leaderboards close in ...</p>
+        <p class="center font-light marginb-small" id="leaderboard-countdown">Leaderboards lock in ...</p>
         <h1 class="margin0 marginb center">Leaderboard for category <span id="leaderboard-category">...</span></h1>
 
         <div class="marginx" id="leaderboard-container">

--- a/pages/index.html
+++ b/pages/index.html
@@ -61,6 +61,7 @@
 
       <div class="section" id="leaderboard">
 
+        <p class="center font-light marginb-small" id="leaderboard-countdown">Leaderboards close in ...</p>
         <h1 class="margin0 marginb center">Leaderboard for category <span id="leaderboard-category">...</span></h1>
 
         <div class="marginx" id="leaderboard-container">

--- a/pages/main.js
+++ b/pages/main.js
@@ -107,6 +107,45 @@ var homepageInit = async function () {
   }
   updateActiveMap();
 
+  const leaderboardCountdown = document.querySelector("#leaderboard-countdown");
+
+  /**
+   * Updates the leaderboard countdown every minute
+   */
+  function updateLeaderboardCountdown () {
+
+    // The time for which the leaderboard is open, in seconds
+    const activeTime = 529200;
+    // The time for which the leaderboard is locked, in seconds
+    const lockedTime = 75600;
+
+    // Get the current time
+    const now = new Date();
+    // Get the start of the week, floored to the nearest hour
+    const start = new Date(config.date * 1000);
+    const startHour = new Date(start.getFullYear(), start.getMonth(), start.getDate(), start.getHours());
+    // Get the time at which the week ends
+    const end = Number(startHour) + activeTime * 1000;
+
+    // Calculate how long (in minutes) until the week ends
+    let mins = (end - now) / 1000 / 60;
+
+    let output = "";
+
+    if (!config.voting) {
+      mins += lockedTime / 60;
+      if (mins > 0) output += `Leaderboards reopen in ${Math.floor(mins / 60 / 24)}d ${Math.floor(mins / 60 % 24)}h ${Math.floor(mins % 60)}m`;
+      else output = "Leaderboards locked";
+    } else {
+      output = `Leaderboards close in ${Math.floor(mins / 60 / 24)}d ${Math.floor(mins / 60 % 24)}h ${Math.floor(mins % 60)}m`;
+    }
+
+    leaderboardCountdown.textContent = output;
+
+  }
+  updateLeaderboardCountdown();
+  setInterval(updateLeaderboardCountdown, 60000);
+
   const leaderboardCategorySelect = document.querySelector("#leaderboard-category-select");
   const leaderboardArchiveSelect = document.querySelector("#leaderboard-archive-select");
 

--- a/pages/main.js
+++ b/pages/main.js
@@ -137,7 +137,7 @@ var homepageInit = async function () {
       if (mins > 0) output += `Leaderboards reopen in ${Math.floor(mins / 60 / 24)}d ${Math.floor(mins / 60 % 24)}h ${Math.floor(mins % 60)}m`;
       else output = "Leaderboards locked";
     } else {
-      output = `Leaderboards close in ${Math.floor(mins / 60 / 24)}d ${Math.floor(mins / 60 % 24)}h ${Math.floor(mins % 60)}m`;
+      output = `Leaderboards lock in ${Math.floor(mins / 60 / 24)}d ${Math.floor(mins / 60 % 24)}h ${Math.floor(mins % 60)}m`;
     }
 
     leaderboardCountdown.textContent = output;


### PR DESCRIPTION
Adds a countdown timer for the leaderboards closing/reopening to the home page. Screenshots below.

Desktop:
![Screenshot 2024-09-23 at 23-21-10 Epochtal](https://github.com/user-attachments/assets/5130865e-b7be-4048-94d4-b0ab0f24701f)

Mobile:
![Screenshot 2024-09-23 at 23-21-55 Epochtal](https://github.com/user-attachments/assets/5915ffad-b2fa-48d8-82a3-8705ca9ad5da)

Closes #101