### PR TITLE
Consider removed runs when assigning points

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -284,7 +284,8 @@ module.exports = async function (args, request) {
       const user = await api_users(["whoami"], request);
       if (!user) return "ERR_LOGIN";
 
-      await leaderboard(["remove", category, user.steamid]);
+      // Remove the run, but don't purge from weeklog
+      await leaderboard(["remove", category, user.steamid, false]);
 
       // Return SUCCESS to the user
       return "SUCCESS";

--- a/util/help.js
+++ b/util/help.js
@@ -31,7 +31,8 @@ Time is provided in seconds, 3 by default.
 Commands:
     list -- lists all categories with leaderboards
     get -- lists all runs in the given category
-    remove STEAMID -- removes a player's run from the given category
+    remove STEAMID PURGE -- removes a player's run from the given category
+        PURGE -- boolean flag - whether to purge the run from the weeklog
     add STEAMID TIME NOTE [PORTALS SEGMENTED] -- adds a run to the given category
         STEAMID -- player's steamid
         TIME -- run time in ticks

--- a/util/leaderboard.js
+++ b/util/leaderboard.js
@@ -74,6 +74,9 @@ module.exports = async function (args, context = epochtal) {
 
       if (lb === undefined) throw new UtilError("ERR_CATEGORY", args, context);
 
+      // Whether the run should be purged from the weeklog (true by default)
+      const purge = args[3] === undefined ? true : args[3];
+
       // Find the run to remove
       const idx = lb.findIndex(function (curr) {
         return curr.steamid === steamid;
@@ -91,7 +94,7 @@ module.exports = async function (args, context = epochtal) {
       if (file) Bun.write(file, JSON.stringify(data));
 
       // Log the removal
-      await weeklog(["add", steamid, category, 0, 0], context);
+      await weeklog(["add", steamid, category, 0, purge ? 1 : 0], context);
 
       return "SUCCESS";
 

--- a/util/points.js
+++ b/util/points.js
@@ -1,5 +1,5 @@
 const UtilError = require("./error.js");
-const leaderboard = require("./leaderboard.js");
+const weeklog = require("./weeklog.js");
 const categories = require("./categories.js");
 const archive = require("./archive.js");
 const profiledata = require("./profiledata.js");
@@ -143,23 +143,22 @@ async function pointsFromSteamID (steamid, context = epochtal) {
  */
 async function calculatePointsDelta (context = epochtal) {
 
-  const boards = await leaderboard(["list"], context);
+  const leaderboard = await weeklog(["reconstruct"], context);
   const catlist = await categories(["list"], context);
   const partners = context.data.week.partners;
   const catDeltaElo = {};
 
-  // For each board (category with at least 1 run)
-  for (let i = 0; i < boards.length; i ++) {
+  // For all categories in reconstructed leaderboard
+  for (const catname in leaderboard) {
 
     // Ensure the category is in the list of active categories at the conclusion of the week
-    const catname = boards[i];
     if (!catlist.includes(catname)) continue;
 
     // Ensure the category is scored
     const cat = await categories(["get", catname], context);
     if (!cat.points) continue;
 
-    const lb = await leaderboard(["get", catname], context);
+    const lb = leaderboard[catname];
 
     catDeltaElo[catname] = {};
     const deltaElo = catDeltaElo[catname];

--- a/util/points.js
+++ b/util/points.js
@@ -143,7 +143,7 @@ async function pointsFromSteamID (steamid, context = epochtal) {
  */
 async function calculatePointsDelta (context = epochtal) {
 
-  // Get a clone of all final leaderboards
+  // Get all final leaderboards
   const allBoards = context.data.leaderboard;
   // Get a reconstruction of the week log as a leaderboard
   const reconstructed = await weeklog(["reconstruct"], context);

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -27,7 +27,9 @@ function parseLog (buffer, categoryList, forcePurge = false) {
     for (let j = 0; j < 8; j ++) {
       steamid += BigInt(buffer[curr + j]) * BigInt(Math.pow(256, 7 - j));
     }
+    // convert the acquired number to a valid steamid string
     entry.steamid = steamid.toString();
+    while (entry.steamid.length < 17) entry.steamid = "0" + entry.steamid;
 
     // 1 byte - category index
     entry.category = categoryList[buffer[curr + 8]];

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -57,7 +57,7 @@ function parseLog (buffer, categoryList, forcePurge = false) {
 
       for (let j = log.length - 1; j >= 0; j --) {
         // look for the last run by the same user in the same category and remove it
-        if (log[j].steamid !== entry.steamid || log[j].category !== entry.category) {
+        if (log[j].steamid === entry.steamid && log[j].category === entry.category) {
           log.splice(j, 1);
           break;
         }

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -211,6 +211,7 @@ module.exports = async function (args, context = epochtal) {
     case "reconstruct": {
 
       const categoryList = await categories(["list"], context);
+      const categoryData = {};
       const date = (await config(["get", "date"], context));
       const buffer = new Uint8Array(await file.arrayBuffer());
 
@@ -221,6 +222,7 @@ module.exports = async function (args, context = epochtal) {
       const lb = {};
       for (let i = 0; i < categoryList.length; i ++) {
         lb[categoryList[i]] = [];
+        categoryData[categoryList[i]] = await categories(["get", categoryList[i]], context);
       }
 
       // Reconstruct each entry into the leaderboard in reverse chronological order
@@ -243,12 +245,8 @@ module.exports = async function (args, context = epochtal) {
 
         let inserted = false;
 
-        // > The weeklog doesn't contain category data, so we don't know if a category is based in portals
-        // > or not. Therefore, unfortunately, 'lp' is hardcoded to be least portals
-        // - PancakeTAS
-
-        // Insert 'lp' data into the leaderboard
-        if (curr.category === "lp") {
+        // Insert portals-first run into the leaderboard
+        if (categoryData[curr.category].portals) {
 
           newRun.segmented = false;
 

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -53,7 +53,9 @@ function parseLog (buffer, categoryList, forcePurge = false) {
     if (entry.time === 0) {
 
       // the portal count byte denotes whether to purge the run from the output entirely
-      if (!forcePurge && entry.portals === 0) continue;
+      const purge = entry.portals === 0;
+      // if we're not purging, just ignore this marker and do nothing
+      if (!forcePurge && !purge) continue;
 
       for (let j = log.length - 1; j >= 0; j --) {
         // look for the last run by the same user in the same category and remove it
@@ -63,10 +65,11 @@ function parseLog (buffer, categoryList, forcePurge = false) {
         }
       }
 
-      continue;
-    }
+    } else {
 
-    log.push(entry);
+      log.push(entry);
+
+    }
 
   }
 

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -9,9 +9,10 @@ const config = require("./config.js");
  *
  * @param {Uint8Array} buffer Buffer containing weeklog data
  * @param {string[]} categoryList  List of categories
+ * @param {boolean} forcePurge Whether to treat all deletion markers as purges (false by default)
  * @returns {object[]} Array of objects representing weeklog entries
  */
-function parseLog (buffer, categoryList) {
+function parseLog (buffer, categoryList, forcePurge = false) {
 
   const log = [];
 
@@ -50,7 +51,7 @@ function parseLog (buffer, categoryList) {
     if (entry.time === 0) {
 
       // the portal count byte denotes whether to purge the run from the output entirely
-      if (entry.portals === 0) continue;
+      if (!forcePurge && entry.portals === 0) continue;
 
       for (let j = log.length - 1; j >= 0; j --) {
         // look for the last run by the same user in the same category and remove it

--- a/util/weeklog.js
+++ b/util/weeklog.js
@@ -50,21 +50,14 @@ function parseLog (buffer, categoryList) {
     if (entry.time === 0) {
 
       // the portal count byte denotes whether to purge the run from the output entirely
-      const purge = entry.portals === 1;
+      if (entry.portals === 0) continue;
 
       for (let j = log.length - 1; j >= 0; j --) {
-        // look for the last run by the same user in the same category
-        if (log[j].steamid !== entry.steamid || log[j].category !== entry.category) continue;
-
-        if (purge) {
-          // if we're purging this run, just splice it from the output
+        // look for the last run by the same user in the same category and remove it
+        if (log[j].steamid !== entry.steamid || log[j].category !== entry.category) {
           log.splice(j, 1);
-        } else {
-          // otherwise, set the run time and portals to zero
-          log[j].time = 0, log[j].portals = 0;
+          break;
         }
-
-        break;
       }
 
       continue;


### PR DESCRIPTION
Uses the weeklog to restore user-deleted runs when calculating elo deltas, and implements a way to distinguish user and admin run deletions. Tested on data copied from the live version at epochtal.p2r3.com. After accounting for edge cases, only 3 runs were considered "missing", each of which I checked individually to ensure that they were indeed removed by the player. Placement on the global leaderboard is hardly different, which I see as a good indication that everything is working correctly.

## Week 146 top 5 standings post-recalculation:
![image](https://github.com/user-attachments/assets/f369cd80-d87b-4f67-ba6e-6d78fb4e90b9)

Edge cases specific to the epochtal.p2r3.com deployment are caused by faulty historical data. Patches for those will be applied to the deployment itself and are not part of this pull request. On a less related note, week logs would _really_ benefit from having an extra byte for flags to mark things like proof type, but that would require lots of awkward leaderboard scraping to grandfather that data into the existing logs. I simply do not have the time for this now. As such, the current implementation is forced to assume all deleted LP runs are segmented.

Closes #24 