### PR TITLE
Make "meme" a video-only category

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -135,7 +135,7 @@ async function setup () {
   await categories(["add", "lp", "Least Portals", true, false, false, "any", true]);
   await categories(["add", "ppnf", "Portal Placement Never Fail", false, false, false, "demo", false]);
   await categories(["add", "tas", "Tool Assisted Speedrun", false, false, false, "any", false]);
-  await categories(["add", "meme", "Meme", false, false, false, "any", false]);
+  await categories(["add", "meme", "Meme", false, false, false, "video", false]);
   await categories(["add", "coop", "Co-op Mode", false, true, false, "demo", true]);
 
   // Delete first archive


### PR DESCRIPTION
This might be a weird proposal. This isn't solving any open issue, or fixing any urgent bug not listed in an issue - this is a very simple change that could've been easily established on my deployment, but I want an area for discussion, and let that be this.

I think the `meme` category would benefit from allowing video-only submissions, as this would most likely improve the quality of runs and reduce the amount of cheap "alternate route" submissions. At the very least, to submit to meme, you'd have to record or render your run and upload it to YouTube.

If this pull request gets merged, I'll update the category on my deployment.