### PR TITLE
Display warning on JS API failure

### DIFF
--- a/defaults/portal2/cfg/epochtal_js_timeout.cfg
+++ b/defaults/portal2/cfg/epochtal_js_timeout.cfg
@@ -1,0 +1,1 @@
+disconnect "The Spplice JS API has not responded, please restart the Spplice package. Demos recorded during this session will not be valid for submission to scored categories."

--- a/defaults/portal2/cfg/valve.rc
+++ b/defaults/portal2/cfg/valve.rc
@@ -30,4 +30,8 @@ con_drawnotify 0
 // Alias level restart
 sar_alias do_reset restart_level
 
+// Set a timeout warning for the JS API
+alias js_test_fail "exec epochtal_js_timeout"
+hwait 60 js_test_fail
+
 startupmenu

--- a/defaults/portal2/main.js
+++ b/defaults/portal2/main.js
@@ -31,6 +31,16 @@ do { // Attempt connection with the game's console
 
 console.log("Connected to Portal 2 console.");
 
+// Prevent JS API timeout from firing
+game.send(gameSocket, "alias js_test_fail\n");
+
+// Check if we can access the API for timestamps
+if (download.string(HTTP_ADDRESS + "/api/timestamp/get")) {
+  game.send(gameSocket, "echo Server timestamp test successful.\n");
+} else {
+  game.send(gameSocket, "disconnect \"Server timestamp test failed, please restart the Spplice package. Demos recorded during this session will not be valid for submission to scored categories.\"\n");
+}
+
 // Keep track of co-op sync pings/pongs
 var pongIgnore = 0;
 // Whether an attempt has been made to provide a WebSocket token


### PR DESCRIPTION
Implements a 1 second timeout for the JS API startup and an early server timestamp check. If either of these fail, a warning is displayed to the user. This is a workaround for a mysterious, irreproducible bug that some players have reported.

Closes #98