### PR TITLE
Fix several small issues with the livestream controller

### DIFF
--- a/defaults/portal2/main.js
+++ b/defaults/portal2/main.js
@@ -186,6 +186,11 @@ function processServerEvent (data) {
       return;
     }
 
+    // Handle requests for console commands
+    case "cmd": {
+      return game.send(gameSocket, data.value);
+    }
+
   }
 
 }

--- a/pages/stream/controller.js
+++ b/pages/stream/controller.js
@@ -90,6 +90,16 @@ const controllerInit = async function () {
 
   };
 
+  // Generates and copies a token for the game client
+  window.copyToken = async function () {
+
+    const token = await (await fetch(`/api/events/auth/streamController`)).json();
+    navigator.clipboard.writeText(`echo ws:${token}`);
+
+    return showPopup("Token copied", "A new token has been copied to your clipboard. It is valid for 30 seconds, starting now.");
+
+  };
+
   const leaderboardContainer = document.querySelector("#controller-leaderboard");
   /**
    * Sets up or updates the leaderboard display

--- a/pages/stream/controller.js
+++ b/pages/stream/controller.js
@@ -19,28 +19,13 @@ const controllerInit = async function () {
   setInterval(() => controllerSocket.send("{}"), 30000);
 
   /**
-   * Sends WebSocket events to the stream controller event topic, which both the UI and controller listen to
+   * Sends WebSocket events to the stream controller event topic, which the UI, game, and controller listen to
    * @param {unknown} data Data to send, converted to a JSON string
    */
   window.sendToController = async function (data) {
 
     const dataString = encodeURIComponent(JSON.stringify(data));
     await fetch(`/util/events/send/streamController/${dataString}`, { method: "POST" });
-
-  };
-
-  /**
-   * Sends WebSocket events to the connected user's client
-   *
-   * @param {string} type Type of event, currently only "cmd" is expected
-   * @param {string} value Data to send, currently expected to be a concommand
-   */
-  window.sendToGame = async function (type, value) {
-
-    const data = encodeURIComponent(JSON.stringify({ type, value }));
-    const response = await (await fetch(`/util/events/send/"game_${whoami.steamid}"/${data}`, { method: "POST" })).json();
-
-    if (response.startsWith("Error: ")) throw response;
 
   };
 
@@ -67,7 +52,7 @@ const controllerInit = async function () {
     window.playSelectedRun = async function () {
 
       if (proof === "demo") {
-        await sendToGame("cmd", `playdemo tournament/${steamid}_${category}`);
+        window.sendToController({ type: "cmd", value: `playdemo tournament/${steamid}_${category}` });
         window.sendToController({ action: "play" });
       } else {
         const link = await (await fetch(`/api/proof/download/"${steamid}"/${category}`)).text();
@@ -97,7 +82,7 @@ const controllerInit = async function () {
   window.returnToLeaderboard = async function () {
 
     window.sendToController({ action: "start" });
-    await sendToGame("cmd", "stopdemo");
+    window.sendToController({ type: "cmd", value: "stopdemo" });
 
     // Disable the "Play Selected Run" button
     playRunButton.style.pointerEvents = "none";

--- a/pages/stream/controller/index.html
+++ b/pages/stream/controller/index.html
@@ -39,6 +39,9 @@
         <i class="fa-solid fa-forward" style="cursor: pointer" id="controller-music-skip"></i>
       </h2>
 
+      <br>
+      <button onclick="copyToken()">Copy Token</button>
+
     </div>
 
     <div id="global-popup">


### PR DESCRIPTION
The stream controller referred to an outdated `game_<steamid>` socket naming scheme (used before game client tokens were a thing), which meant that the host would have to manually create this event and request a token for it via the API, as well as hardcode it to ping repeatedly to prevent timeouts. This has been fixed by instead reusing the `streamController` socket for both the controller and the game client, and adding a frontend for requesting a token, much like you would in Epochtal Live. The base Epochtal Spplice package was also missing an event handler for `cmd` events, which has been added back.

This code (or rather something very similar) has been sitting on my deployment for a while now. This pull request makes it less hacky and aims to finally get it upstream.