### PR TITLE
fix(discord): properly sanitize usernames and map names

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -51,12 +51,12 @@ async function discordUpdate (steamid, category) {
   const time = ticksToString(run.time);
 
   let emoji = "🎲";
-  let output = `**${user.name.replaceAll("\\", "\\\\").replaceAll("@", "\\@")}**`;
+  let output = `**${user.name.replaceAll(/[*@_~`#[\]()\-.>\\:]/g, "\\$&")}**`;
 
   if (currCategory.coop) {
     const partners = await config(["get", "partners"]);
     const partner = await users(["get", partners[steamid]]);
-    output += ` and **${partner.name.replaceAll("\\", "\\\\").replaceAll("@", "\\@")}**`;
+    output += ` and **${partner.name.replaceAll(/[*@_~`#[\]()\-.>\\:]/g, "\\$&")}**`;
   }
 
   output += ` submitted a new${run.segmented ? " segmented" : ""} run to "${currCategory.title}" with a time of \`${time}\``;
@@ -157,7 +157,7 @@ module.exports = async function (args, request) {
           fs.rmSync(path);
 
           // Report the run on the discord
-          const reportText = `${user.username}'s run was rejected. ${verdict}\nSteam ID: \`${user.steamid}\``;
+          const reportText = `${user.username.replaceAll(/[*@_~`#[\]()\-.>\\:]/g, "\\$&")}'s run was rejected. ${verdict}\nSteam ID: \`${user.steamid}\``;
           await discord(["report", reportText]);
 
           // Return the verdict to the user

--- a/routines/epochtal.js
+++ b/routines/epochtal.js
@@ -352,7 +352,7 @@ async function releaseMap (context) {
   await Bun.write(context.file.log, "");
 
   // Announce the new week on Discord
-  await discord(["announce", "@everyone " + announceText.replaceAll("\\", "\\\\").replaceAll("@", "\\@")], context);
+  await discord(["announce", "@everyone " + announceText.replaceAll(/[*@_~`#[\]()\-.>\\:]/g, "\\$&")], context);
 
   return "SUCCESS";
 


### PR DESCRIPTION
As recently was discovered, people can name themselves as links and those names would work as links, resulting in Discord showing the embeds and such. To mitigate this I propose adding a `\` before all special characters (```*@_~`#[]()-.>\:```), not just `\` and `@`.

For some reason adding `\` to `@everyone` still results in ping, however it no longer renders as a mention in the discord UI.