### PR TITLE
feat(stream ui): use YouTube Iframe API for playing videos

### DIFF
--- a/pages/stream/index.html
+++ b/pages/stream/index.html
@@ -7,11 +7,12 @@
     <link rel="stylesheet" href="/stream/stream.css">
     <script src="https://w.soundcloud.com/player/api.js"></script>
     <script src="https://kit.fontawesome.com/fc2642e2d1.js" crossorigin="anonymous"></script>
+    <script src="https://www.youtube.com/iframe_api"></script>
   </head>
   <body>
 
     <iframe id="soundcloud" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/user-791186860/sets/epochtal-weekly-tournaments&auto_play=false"></iframe>
-    <iframe id="youtube" width="1920" height="1080" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    <iframe id="youtube" style="display: none" width="1920" height="1080" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen src="https://www.youtube-nocookie.com/embed/00000000000?vq=high&enablejsapi=1"></iframe>
 
     <div id="bg-anim-container">
       <div id="bg-anim-bg"></div>

--- a/pages/stream/main.js
+++ b/pages/stream/main.js
@@ -42,7 +42,15 @@ const initializeUI = async function () {
   const leaderboardElement = document.querySelector("#leaderboard");
   const titleElement = document.querySelector("#title");
   const backgroundAnimation = document.querySelector("#bg-anim-container");
-  const youtubeEmbed = document.querySelector("#youtube");
+  const youtubeEmbed = new YT.Player("youtube", {
+    events: {
+      "onStateChange": ({data})=>{
+        if (data === YT.PlayerState.ENDED) {
+          youtubeEmbed.stopVideo();
+        }
+      }
+    }
+  });
 
   const runElementContainer = document.querySelector("#runinfo");
   const runNameElement = document.querySelector("#runinfo-name");
@@ -288,8 +296,11 @@ const initializeUI = async function () {
     else videoID = link.split("youtu.be/")[1].split("?")[0];
 
     // Activate the YouTube embed
-    youtubeEmbed.style.display = "block";
-    youtubeEmbed.src = `https://www.youtube-nocookie.com/embed/${videoID}?autoplay=1&vq=high`;
+    youtubeEmbed.getIframe().style.display = "block";
+    youtubeEmbed.cueVideoById(videoID);
+    setTimeout(function () {
+      youtubeEmbed.playVideo();
+    }, 1500);
 
   };
 
@@ -301,8 +312,8 @@ const initializeUI = async function () {
     backgroundAnimation.style.opacity = 1;
 
     setTimeout(function () {
-      youtubeEmbed.src = "";
-      youtubeEmbed.style.display = "none";
+      youtubeEmbed.stopVideo();
+      youtubeEmbed.getIframe().style.display = "none";
       contentContainer.style.pointerEvents = "auto";
     }, 500);
 


### PR DESCRIPTION
So youtube displays (un)related videos after the end of the playback. They have nothing to do with the tourney, a lot of times their names aren't even in English, and sometimes mention politics. With the use of IFrame Player API this PR would stops those videos from showing and display the original video's thumbnail instead.

Also the API allows to run code when video playback ends, which would be useful in case we decide to automate returning to the leaderboard. Or to control the video (seek, play/pause, volume) from code, which would be useful in case we decide to add those controls into the stream UI controller, removing the need to interact with the stream UI directly in OBS.

Unfortunately, (un)related videos still display themselves if you pause the video, and there seems to be no workarounds in the API. But in the future we can just put them off screen (with the entire UI of the embed, so we'll need to have controls elsewhere)!

This PR, maybe doesn't shine on its own, is a gateway to beautiful world of stream UI improvements, which would make streaming easier than it can ever be! Don't worry, I'll write the code.