### PR TITLE
fix(demo recording): adress server timestamp not found problem.

### DIFF
--- a/defaults/portal2/polyfill.js
+++ b/defaults/portal2/polyfill.js
@@ -31,6 +31,14 @@ var game = {
   connect () {
     return 1;
   },
+  disconnect () {
+    return 0;
+  },
+  status () {
+    // this gets called in read() or send() failed. I don't know how to handle it in spplice 2, se let's assume stuff
+    // already hit the fan and lie that the game is not running and let script just exit by the logic that calls this
+    return false;
+  },
   // Treat the console data string as a FIFO buffer
   read (_, n = 1024) {
     const out = __pfConsoleData.slice(0, n);


### PR DESCRIPTION
Sometimes Portal 2 prints to console some non-printable characters, which make Spplice 3 js interpreter error, the error is not handeled, the js stops executing and no server timestamps get injected into demos, resulting in them being rejected.

By adding some try/catch logic to places that are proven to throw said error and to the main loop, this PR aims at making the js script more robust and less likely (hopefully not likely at all) to stop working for no reason.

Also more try/catch logic was added to Epochtal Live Spplice package, since I was informed, that the issue was only partially fixed in Epochtal Live package.