### PR TITLE
Implement scoring for Random Maps Ranked mode

### DIFF
--- a/pages/live/lobby.js
+++ b/pages/live/lobby.js
@@ -93,6 +93,14 @@ async function updatePlayerList () {
     const run = leaderboard.find(c => c.steamid === steamid);
     // Get the player's win count
     const wins = lobby.data.players[steamid].wins || 0;
+    // Generate displayed text for win count
+    let winsText = `${wins} win${wins === 1 ? "" : "s"}`;
+    // In Random Maps Ranked mode, replace win count with player Elo
+    if (lobby.listEntry.mode === "random_ranked") {
+      const points = Math.round(users[steamid].points.random_ranked);
+      if (!points) winsText = `No points yet`;
+      else winsText = `${points} point${points === 1 ? "" : "s"}`;
+    }
 
     // Get the player's ready state
     const ready = lobby.data.players[steamid].ready;
@@ -121,7 +129,7 @@ async function updatePlayerList () {
       onclick="transferHost('${steamid}')"
       ` : "")}
   >
-  <p class="lobby-player-name">${username}${run ? ` - ${ticksToString(run.time)}` : ""}<br><span class="lobby-player-wins">${wins} win${wins === 1 ? "" : "s"}</span></p>
+  <p class="lobby-player-name">${username}${run ? ` - ${ticksToString(run.time)}` : ""}<br><span class="lobby-player-wins">${winsText}</span></p>
   <i
     class="${isSpectator ? "fa-regular fa-eye" : (ready ? (ingame ? "fa-solid fa-circle-play" : "fa-solid fa-circle-check") : "fa-regular fa-circle")} lobby-player-ready"
     onmouseover="showTooltip('${isSpectator ? "Spectating" : (ready ? (ingame ? "Playing" : "Ready") : "Not ready")}')"
@@ -407,6 +415,7 @@ async function lobbyEventHandler (event) {
       if (lobby.listEntry.mode === "random_ranked") {
         updateLobbyMap();
       }
+      updatePlayerList();
 
       // Change the lobby mode text
       const modeString = lobbyModeStrings[lobby.listEntry.mode];
@@ -510,6 +519,10 @@ async function lobbyEventHandler (event) {
         if (run.placement !== 1) continue;
         if (!(run.steamid in lobby.data.players)) continue;
         lobby.data.players[run.steamid].wins ++;
+      }
+      // In Random Maps Ranked mode, re-fetch player list to update Elo
+      if (lobby.listEntry.mode === "random_ranked") {
+        users = await (await fetch("/api/users/get")).json();
       }
       updatePlayerList();
 

--- a/pages/main.js
+++ b/pages/main.js
@@ -200,6 +200,11 @@ var homepageInit = async function () {
 
     }
 
+    // Add Random Maps Ranked leaderboard to player profiles category dropdown.
+    // Note: not sure if it should be here? While this does seem like the
+    // only sensible spot, this list is generally reserved for the weekly categories.
+    outputPlayers += `<option value="random_ranked">Random Maps Ranked</option>`;
+
     leaderboardCategorySelect.innerHTML = outputLeaderboard;
     playersCategorySelect.innerHTML = outputPlayers;
 
@@ -901,6 +906,8 @@ var homepageInit = async function () {
       let pointsString = "Points hidden";
       const outputPoints = Math.round(user.points[category]);
       if (user.points[category] !== -Infinity) pointsString = `${outputPoints} point${outputPoints === 1 ? "" : "s"}`;
+      // HACK: For Random Maps Ranked, don't show players who've never played it
+      else if (category === "random_ranked") continue;
 
       output += `<a href="${window.location.protocol}//${window.location.host}/profile/#${user.steamid}" target="_blank" style="color:white;text-decoration:none"><div class="lb-entry lb-rank${placement}">
         <p class="lb-text">${username}</p>

--- a/util/lobbies.js
+++ b/util/lobbies.js
@@ -4,6 +4,7 @@ const users = require("./users.js");
 const events = require("./events.js");
 const workshopper = require("./workshopper.js");
 const leaderboard = require("./leaderboard.js");
+const points = require("./points.js");
 
 const [LOBBY_IDLE, LOBBY_INGAME] = [0, 1];
 
@@ -124,7 +125,48 @@ async function handleStateChange (id, context, init = false) {
 
   switch (mode) {
     case "ffa": break;
-    case "random_ranked":
+    case "random_ranked": {
+      // When a match finishes, calculate new Elo for all players
+      if (state === LOBBY_IDLE && !init) {
+        // Get user data
+        const usersFile = context.file.users;
+        const usersData = context.data.users;
+        // Get leaderboard of runs
+        const lb = await leaderboard(["get", "lobby"], dataEntry.context);
+        // Calculate new Elo deltas for each matchup
+        const deltas = new Map(); // <steamid, elo delta>
+        for (let i = 0; i < lb.length; i ++) {
+          const selfID = lb[i].steamid;
+          // Don't count spectators in Elo calculation
+          if (dataEntry.spectators.includes(selfID)) continue;
+          // Get current Elo, assume 1000 if unset
+          const selfPoints = usersData[selfID].points.random_ranked || 1000
+          for (let j = 0; j < lb.length; j ++) {
+            if (i === j) continue;
+            const opponentID = lb[j].steamid;
+            // Don't count spectators in Elo calculation
+            if (dataEntry.spectators.includes(opponentID)) continue;
+            const opponentPoints = usersData[opponentID].points.random_ranked || 1000;
+            const outcome = (lb[i].time < lb[j].time) ? 1 : (lb[i].time === lb[j].time ? 0 : -1);
+            const delta = await points(["delta", selfPoints, opponentPoints, outcome]);
+            if (!deltas.has(selfID)) deltas.set(selfID, delta);
+            else deltas.set(selfID, deltas.get(selfID) + delta);
+          }
+        }
+        // Apply deltas to user profiles, scaled by player count
+        for (const player of listEntry.players) {
+          if (!deltas.has(player)) continue;
+          // Start new players at 1000 Elo
+          const currentPoints = usersData[player].points.random_ranked || 1000;
+          // Scale applied delta to (player count - 1)
+          const scaledDelta = deltas.get(player) / (deltas.size - 1);
+          const newPoints = Number((currentPoints + scaledDelta).toFixed(2));
+          usersData[player].points.random_ranked = newPoints;
+        }
+        if (usersFile) Bun.write(usersFile, JSON.stringify(usersData));
+      }
+      // Fall through to "random" case
+    }
     case "random": {
       if (state === LOBBY_INGAME) break;
       // Pick a random map whenever the lobby becomes idle
@@ -836,8 +878,8 @@ module.exports = async function (args, context = epochtal) {
           const previousState = dataEntry.state;
           dataEntry.state = LOBBY_IDLE;
           if (previousState === LOBBY_INGAME) {
-            await events(["send", eventName, { type: "lobby_finish" }], context);
             await handleStateChange(lobbyid, context);
+            await events(["send", eventName, { type: "lobby_finish" }], context);
           }
         }
 

--- a/util/points.js
+++ b/util/points.js
@@ -398,6 +398,10 @@ module.exports = async function (args, context = epochtal) {
 
     }
 
+    case "delta": {
+      return calculateEloDelta(...args.slice(1)).player;
+    }
+
   }
 
   throw new UtilError("ERR_COMMAND", args, context);


### PR DESCRIPTION
Implements basic Elo-based scoring for Random Maps Ranked in Epochtal Live.

Has been tested, at least enough to confirm that basic functionality works and nothing else has been broken. I doubt that anyone else here will manage do to any further testing before deployment, so I'll just merge this right away and wait for SuperAiderton and others to complain if something breaks.

Again, this doesn't touch base Epochtal functionality, just lobbies.