### PR TITLE
Fix broken June 2012 PeTI exits

### DIFF
--- a/defaults/live/mapspawn.nut
+++ b/defaults/live/mapspawn.nut
@@ -55,7 +55,7 @@ if (!("Entities" in this)) return;
   local pelletWarning = Entities.FindByName(null, "@stop_for_pellets");
   if (pelletWarning) pelletWarning.Destroy();
 
-  // End run on PTI restart trigger
+  // End run on PeTI restart trigger
   local restartTrigger = Entities.FindByName(null, "@preview_restart_trigger");
   if (restartTrigger) {
     local hookFunction = function ():(restartTrigger) {
@@ -76,7 +76,7 @@ if (!("Entities" in this)) return;
       }
     }
   }
-  // Slightly more rigorous check for PTI restart text
+  // Slightly more rigorous check for PeTI restart text
   local restartText = Entities.FindByName(null, "@preview_complete_message");
   if (!restartText) restartText = Entities.FindByName(null, "preview_complete_message");
   if (restartText) if (restartText.ValidateScriptScope()) {

--- a/defaults/live/mapspawn.nut
+++ b/defaults/live/mapspawn.nut
@@ -54,6 +54,28 @@ if (!("Entities" in this)) return;
   // Fix BEEmod maps with pellet dependency
   local pelletWarning = Entities.FindByName(null, "@stop_for_pellets");
   if (pelletWarning) pelletWarning.Destroy();
+  
+  // Fix broken PeTI exit airlock door in maps last updated in June 2012
+  IncludeScript("june_2012_airlock_fixup");
+  local mapName = GetMapName();
+  local mapKey = mapName.slice(9); // 9 is the length of "workshop/"
+  local indexOfBackslash = mapKey.find("\\");
+  if (indexOfBackslash != null) {
+    mapKey = mapKey.slice(0, indexOfBackslash) + "/" + mapKey.slice(indexOfBackslash + 1);
+  }
+  if (mapKey in ::__elAirlockFixupTable) {
+    local existingRelayIdx = ::__elAirlockFixupTable[mapKey];
+    local existingRelayName = "InstanceAuto" + existingRelayIdx + "-relay_leaving_level";
+    local newRelay = Entities.CreateByClassname("logic_relay");
+    newRelay.__KeyValueFromString("Targetname", "doorexit1-relay_leaving_level");
+    if (newRelay.ValidateScriptScope()) {
+      local scope = newRelay.GetScriptScope();
+      scope["InputEnable"] <- function ():(existingRelayName) {
+        EntFire(existingRelayName, "Enable");
+      };
+      scope["Inputenable"] <- scope["InputEnable"];
+    }
+  }
 
   // End run on PeTI restart trigger
   local restartTrigger = Entities.FindByName(null, "@preview_restart_trigger");

--- a/defaults/portal2/scripts/vscripts/mapspawn.nut
+++ b/defaults/portal2/scripts/vscripts/mapspawn.nut
@@ -283,7 +283,7 @@ ppmod.onauto(async(function () {
     local player = IsMultiplayer() ? ppmod.get("blue") : GetPlayer();
     local startPos = player.GetOrigin();
 
-    // PeTI and BEEMod maps have world portals at the entrance
+    // PeTI and BEEmod maps have world portals at the entrance
     local wPartner, wPortal = ppmod.get(startPos, 1024, "linked_portal_door");
     if (wPortal) {
       wPartner = wPortal.GetPartnerInstance();

--- a/util/curator.js
+++ b/util/curator.js
@@ -239,7 +239,7 @@ function calculateDensities (entities) {
   entities.sort((a, b) => a.distance - b.distance);
   const median = entities[Math.floor(entities.length / 2)];
   const mapSize = median.distance * 1.5;
-  // The volume of the map in 128x128x128 chunks (PTI blocks)
+  // The volume of the map in 128x128x128 chunks (PeTI blocks)
   const mapSizeBlocks = Math.pow(mapSize, 3) / VOLUME_BLOCK_SIZE;
 
   // Count the amount of entities in the map, with separate counters for each entity type
@@ -329,7 +329,7 @@ module.exports = async function (args, context = epochtal) {
       const description = data.file_description.replaceAll("\r", "").toLowerCase();
       const allText = title + description;
 
-      // Tags aren't overused (PTI and BEEMod maps often do this by default)
+      // Tags aren't overused (PeTI and BEEmod maps often do this by default)
       if (data.tags.length < 10) points += weights.v1.TAGS_COUNT;
 
       // Custom visuals (sometimes indicative of genuine attention to detail)
@@ -338,7 +338,7 @@ module.exports = async function (args, context = epochtal) {
       // Map was published through Portal 2 Authoring Tools
       if (data.creator_appid === 644) points += weights.v1.HAMMER;
 
-      // Custom filename - some maps are brought in from PTI into Hammer, this might filter some of those out
+      // Custom filename - some maps are brought in from PeTI into Hammer, this might filter some of those out
       if (isNaN(data.filename.split("/").pop().split(".bsp")[0])) points += weights.v1.FILENAME;
 
       // Multi-line description
@@ -352,7 +352,7 @@ module.exports = async function (args, context = epochtal) {
       // Map doesn't focus on turrets (subjectively makes for a worse speedrunning experience)
       if (!allText.includes("turret")) points += weights.v1.TEXT_TURRETS;
 
-      // Doesn't mention BEEMod - might indicate less overuse of BEEMod-specific elements
+      // Doesn't mention BEEmod - might indicate less overuse of BEEmod-specific elements
       if (!allText.includes("beemod") && !(/bee\d/.test(allText)) && !(/bee \d/.test(allText))) points += weights.v1.TEXT_BEEMOD;
 
       // Map isn't a chamber recreation - this is important, we want to have original routes

--- a/util/workshopper.js
+++ b/util/workshopper.js
@@ -176,7 +176,7 @@ async function rebuildRandomMapCache (node = null) {
     node = randomMapCache;
     // Store cache creation date for expiry checks later
     randomMapCache.created = Date.now();
-    // Use date range between PTI release and today
+    // Use date range between PeTI release and today
     node.start = Math.floor(new Date("2012-05-08").getTime() / 1000);
     node.end = Math.floor(new Date().getTime() / 1000);
   }
@@ -339,11 +339,11 @@ async function isMapPossible (data) {
   // This is used to reject maps that are verifiably unsolvable
   const entities = await curator(["entities", data]);
 
-  // If this specific entity starts enabled, it's the preview build of a PTI map
+  // If this specific entity starts enabled, it's the preview build of a PeTI map
   // These are unbeatable, because they'll restart once you cross the exit door
   if (entities.find(e => e.targetname === "InstanceAuto3-player_start_rl" && e.startdisabled == 0)) return false;
 
-  // In Hammer maps, the only risk is a missing PTI level end output
+  // In Hammer maps, the only risk is a missing PeTI level end output
   if (data.creator_appid !== 620) {
     // Reroll maps that have no entities pointing to the level end relay
     if (!entities.find(function (entity) {


### PR DESCRIPTION
Many PeTI singleplayer maps last updated in June 2012 have broken airlock exit doors.
This fixes these exits to allow these maps to be completed as normal.